### PR TITLE
Multistore publish synchronize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,30 @@
 language: php
 
-php:
-    - 5.6
-    - 7.0
+sudo: false
 
-cache:
-    directories:
-        - vendor
-        - $HOME/.composer/cache
+php:
+  - 7.1
 
 env:
-    global:
-        - APPLICATION_ENV=development
-        - APPLICATION_STORE=DE
+  global:
+    - DEFAULT=1
 
-install:
-    - composer self-update && composer --version
-    - composer install --no-interaction --prefer-dist
+matrix:
+  include:
+    - php: 7.2
+      env: PHPCS=1 DEFAULT=0
+
+  fast_finish: true
+
+  allow_failures:
+    - php: 7.1
+
+before_script:
+  - composer install --prefer-dist --no-interaction
 
 script:
-    - vendor/bin/phpcs src --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml
-    - vendor/bin/codecept run --env isolated --coverage-xml
-
-after_success:
-    - vendor/bin/coveralls -vvv
+  - if [[ $DEFAULT == 1 ]]; then vendor/bin/codecept run ; fi
+  - if [[ $PHPCS == 1 ]]; then composer cs-check ; fi
 
 notifications:
-    email: false
+  email: false

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "SynchronizationBehavior module",
   "license": "proprietary",
   "require": {
-    "spryker/kernel": "^3.21.0",
+    "spryker/kernel": "^3.20.0",
     "spryker/propel-orm": "^1.6.0",
     "spryker/zend": "^2.1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,13 @@
     "spryker/propel-orm": "^1.0.0",
     "spryker/zend": "^2.1.0"
   },
-  "suggest": {
+  "require-dev" : {
     "spryker/queue": "^1.2.0",
-    "spryker/synchronizationBehavior": "^0.1.0"
+    "spryker/synchronization": "^0.1.0 || ^0.2.0"
+  },
+  "suggest": {
+    "spryker/queue": "Generated classes are using spryker/queue module.",
+    "spryker/synchronization": "Generated classes are using spryker/synchronization module."
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "spryker/zend": "^2.1.0"
   },
   "require-dev" : {
-    "spryker/queue": "^1.2.0",
+    "spryker/queue": "^1.1.0",
     "spryker/synchronization": "^0.1.0 || ^0.2.0"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "spryker/zend": "^2.1.0"
   },
   "require-dev" : {
+    "spryker/code-sniffer": "*",
     "spryker/queue": "^1.1.0",
     "spryker/synchronization": "^0.1.0 || ^0.2.0"
   },
@@ -16,9 +17,17 @@
     "spryker/queue": "Generated classes are using spryker/queue module.",
     "spryker/synchronization": "Generated classes are using spryker/synchronization module."
   },
+  "support": {
+    "source": "https://github.com/spryker/synchronization-behavior"
+  },
   "autoload": {
     "psr-4": {
       "Spryker\\": "src/Spryker/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "SprykerTest\\": "tests/SprykerTest/"
     }
   },
   "minimum-stability": "dev",
@@ -32,5 +41,10 @@
   },
   "config": {
     "sort-packages": true
-  }
+  },
+  "scripts": {
+    "cs-check": "phpcs --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v --ignore=/synchronization-behavior/vendor/,/templates/ ./",
+    "cs-fix": "phpcbf --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v --ignore=/synchronization-behavior/vendor/,/templates/ ./"
+  },
+  "include-path":  ["src/"]
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "spryker/zend": "^2.1.0"
   },
   "suggest": {
+    "spryker/queue": "^1.2.0",
     "spryker/synchronizationBehavior": "^0.1.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "description": "SynchronizationBehavior module",
   "license": "proprietary",
   "require": {
-    "spryker/kernel": "^3.4.0",
-    "spryker/propel-orm": "^1.0.0",
+    "spryker/kernel": "^3.21.0",
+    "spryker/propel-orm": "^1.6.0",
     "spryker/zend": "^2.1.0"
   },
   "require-dev" : {

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/Exception/InvalidConfigurationException.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/Exception/InvalidConfigurationException.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception;
+
+use Propel\Runtime\Exception\PropelException;
+
+class InvalidConfigurationException extends PropelException
+{
+}

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -368,7 +368,7 @@ protected function setGeneratedKey()
     }
 
     /**
-     * @throws InvalidConfigurationException
+     * @throws \Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\InvalidConfigurationException
      *
      * @return string
      */
@@ -390,7 +390,7 @@ protected function setGeneratedKey()
         }
 
         if ($queuePoolName) {
-            $setMessageQueueRouting =  "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
+            $setMessageQueueRouting = "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
         }
 
         if ($queueName === null) {

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -205,10 +205,14 @@ public function isSendingToQueue()
 
 /**
  * @param bool \$_isSendingToQueue
+ *
+ * @return \$this
  */
 public function setIsSendingToQueue(\$_isSendingToQueue)
 {
     \$this->_isSendingToQueue = \$_isSendingToQueue;
+    
+    return \$this;
 }        
         ";
     }

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -21,6 +21,7 @@ class SynchronizationBehavior extends Behavior
     protected $parameters = [
         'resource' => null,
         'queue_group' => null,
+        'queue_pool' => null,
     ];
 
     /**
@@ -365,8 +366,14 @@ protected function setGeneratedKey()
     {
         $queueName = $this->getParameter('queue_group')['value'];
 
+        $setQueuePool = '';
+        $queuePoolName = $this->getQueuePoolName();
+        if ($queuePoolName) {
+            $setQueuePool =  "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
+        }
+
         $assignMessageToStore = '';
-        if ($this->hasStore()) {
+        if ($this->hasStore() && !$queuePoolName) {
             $assignMessageToStore = "\$queueSendTransfer->setStoreName(\$this->store);";
         }
 
@@ -388,6 +395,7 @@ protected function sendToQueue(array \$message)
     
     \$queueSendTransfer = new \\Generated\\Shared\\Transfer\\QueueSendMessageTransfer();
     \$queueSendTransfer->setBody(json_encode(\$message));
+    $setQueuePool
     $assignMessageToStore
     
     \$queueClient = \$this->_locator->queue()->client();
@@ -493,6 +501,23 @@ public function syncUnpublishedMessage()
     protected function hasStore()
     {
         return isset($this->getParameters()['store']);
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getQueuePoolName()
+    {
+        $parameters = $this->getParameters();
+        if (!isset($parameters['queue_pool'])) {
+            return null;
+        }
+
+        if (!isset($parameters['queue_pool']['value'])) {
+            return null;
+        }
+
+        return $parameters['queue_pool']['value'];
     }
 
     /**

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -365,18 +365,20 @@ protected function setGeneratedKey()
     protected function addSendToQueueMethod()
     {
         $queueName = $this->getParameter('queue_group')['value'];
-
-        $assignMessageToStore = '';
-        $assignMessageToQueuePool = '';
-
         $queuePoolName = $this->getQueuePoolName();
-        if ($queuePoolName) {
-            $assignMessageToQueuePool =  "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
+        $hasStore = $this->hasStore();
+
+        // TODO: after Ehsan's ticket is merged, throw an exception when both parameter is defined
+        if ($hasStore && $queuePoolName) {
         }
 
-        if ($this->hasStore() && !$queuePoolName) {
-            // TODO: after Ehsan's ticket is merged, throw an exception when both parameter is defined
-            $assignMessageToStore = "\$queueSendTransfer->setStoreName(\$this->store);";
+        $setMessageQueueRouting = '';
+        if ($hasStore) {
+            $setMessageQueueRouting = "\$queueSendTransfer->setStoreName(\$this->store);";
+        }
+
+        if ($queuePoolName) {
+            $setMessageQueueRouting =  "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
         }
 
         if ($queueName === null) {
@@ -397,8 +399,7 @@ protected function sendToQueue(array \$message)
     
     \$queueSendTransfer = new \\Generated\\Shared\\Transfer\\QueueSendMessageTransfer();
     \$queueSendTransfer->setBody(json_encode(\$message));
-    $assignMessageToQueuePool
-    $assignMessageToStore
+    $setMessageQueueRouting
     
     \$queueClient = \$this->_locator->queue()->client();
     \$queueClient->sendMessage('$queueName', \$queueSendTransfer);

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -365,6 +365,11 @@ protected function setGeneratedKey()
     {
         $queueName = $this->getParameter('queue_group')['value'];
 
+        $assignMessageToStore = '';
+        if ($this->hasStore()) {
+            $assignMessageToStore = "\$queueSendTransfer->setStoreName(\$this->store);";
+        }
+
         if ($queueName === null) {
             $queueName = $this->getParameter('resource')['value'];
         }
@@ -383,6 +388,7 @@ protected function sendToQueue(array \$message)
     
     \$queueSendTransfer = new \\Generated\\Shared\\Transfer\\QueueSendMessageTransfer();
     \$queueSendTransfer->setBody(json_encode(\$message));
+    $assignMessageToStore
     
     \$queueClient = \$this->_locator->queue()->client();
     \$queueClient->sendMessage('$queueName', \$queueSendTransfer);
@@ -479,6 +485,14 @@ public function syncUnpublishedMessage()
     \$this->sendToQueue(\$message);
 }        
         ";
+    }
+
+    /**
+     * @return bool
+     */
+    protected function hasStore()
+    {
+        return isset($this->getParameters()['store']);
     }
 
     /**

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -366,14 +366,16 @@ protected function setGeneratedKey()
     {
         $queueName = $this->getParameter('queue_group')['value'];
 
-        $setQueuePool = '';
+        $assignMessageToStore = '';
+        $assignMessageToQueuePool = '';
+
         $queuePoolName = $this->getQueuePoolName();
         if ($queuePoolName) {
-            $setQueuePool =  "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
+            $assignMessageToQueuePool =  "\$queueSendTransfer->setQueuePoolName('$queuePoolName');";
         }
 
-        $assignMessageToStore = '';
         if ($this->hasStore() && !$queuePoolName) {
+            // TODO: after Ehsan's ticket is merged, throw an exception when both parameter is defined
             $assignMessageToStore = "\$queueSendTransfer->setStoreName(\$this->store);";
         }
 
@@ -395,7 +397,7 @@ protected function sendToQueue(array \$message)
     
     \$queueSendTransfer = new \\Generated\\Shared\\Transfer\\QueueSendMessageTransfer();
     \$queueSendTransfer->setBody(json_encode(\$message));
-    $setQueuePool
+    $assignMessageToQueuePool
     $assignMessageToStore
     
     \$queueClient = \$this->_locator->queue()->client();

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -135,7 +135,7 @@ class SynchronizationBehavior extends Behavior
                 $table->addColumn([
                     'name' => 'store',
                     'type' => 'VARCHAR',
-                    'size' => '4',
+                    'size' => '128',
                     'required' => $required,
                 ]);
             }


### PR DESCRIPTION
- Developer(s): @ehsanmx, @gerner-spryker

- Peer Reviewer:

- Ticket: https://spryker.atlassian.net/browse/CORE-2793
- Ticket: https://spryker.atlassian.net/browse/CORE-2977 

- Core PR:

- Release Overview: -

#### Please confirm

- [x] No new OS components - or they have been approved by legal department
- [x] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [x] Functional documentation provided or in progress?
- [x] Integration guide for projects provided or not needed?
- [x] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior              | major                |                      |

#### Release Notes

Entity related change (save/delete) emitted synchronisation messages can target different pools based on either "Store" or a pre defined queue pool.

-----------------------------------------

#### Module SynchronizationBehavior

_**Mini-Major:** Added functionality with incompatible API changes_

Def of done (by responsible developer):
- [x] All methods in facade, client and plugin interfaces provide an [API-doc](https://academy.spryker.com/understanding_spryker/definition_api.html).
- [x] New code fits to the architecture rules.
- [x] All new or changed business logic is covered by functional tests (in Zed business layer).
- [x] Migration guide provided.

##### Change log

Improvements

- Adding and updating missing module requirements in composer.json.
- The generated `sendToQueue()` methods in propel models with the synchronization behavior will also add the Store value to the message or the pool name if any of them is defined.