### PR TITLE
GLUE-317: Extended synchronization behavior with export resource mappings functionality

### DIFF
--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -331,7 +331,6 @@ protected function setGeneratedKeyForMappingResource()
         $keySuffix = null;
         $storeSetStatement = $this->getStoreStatement($parameters);
         $localeSetStatement = $this->getLocaleStatement($parameters);
-        $referenceSetStatement = '';
         $checkSuffixStatement = '';
 
         if (!isset($parameters['resource']['value'])) {
@@ -343,6 +342,7 @@ protected function setGeneratedKeyForMappingResource()
         }
 
         $mappingResourceSuffix = "'{$parameters['mapping_resource']['value']}'";
+        $referenceSetStatement = "\$syncTransferData->setReference($mappingResourceSuffix);";
 
         $resource = $parameters['resource']['value'];
 
@@ -353,10 +353,6 @@ protected function setGeneratedKeyForMappingResource()
          return;       
     }
             ";
-        }
-
-        if ($keySuffix !== null) {
-            $referenceSetStatement = "\$syncTransferData->setReference($mappingResourceSuffix);";
         }
 
         if ($keySuffix !== null) {

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -350,9 +350,9 @@ protected function setMappingResourceGeneratedKey()
 
         $resource = $parameters['resource']['value'];
 
-        if (isset($parameters['mapping_resource_suffix_column'])) {
+        if (isset($parameters['mapping_resource_key_suffix_column'])) {
             $filter = new UnderscoreToCamelCase();
-            $keySuffix = sprintf('get%s()', $filter->filter($parameters['mapping_resource_suffix_column']['value']));
+            $keySuffix = sprintf('get%s()', $filter->filter($parameters['mapping_resource_key_suffix_column']['value']));
             $checkSuffixStatement = "if (empty(\$this->$keySuffix)) {
          return;       
     }
@@ -531,6 +531,7 @@ protected function sendToQueue(array \$message)
                 'key' => \$this->getMappingResourceKey(),
                 'value' => [
                     'key' => \$this->getKey(),
+                    '_timestamp' => microtime(true),
                 ],
                 'resource' => '$resource',
                 'params' => \$decodedParams,
@@ -601,7 +602,10 @@ public function syncPublishedMessage()
         \$message = [
             'delete' => [
                 'key' => \$this->getMappingResourceKey(),
-                'value' => \$data,
+                'value' => [
+                    'key' => \$this->getKey(),
+                    '_timestamp' => microtime(true),
+                ],
                 'resource' => '$resource',
                 'params' => \$decodedParams,
             ]


### PR DESCRIPTION
- Developer(s): @valerio8787

- Peer Reviewer: @ehsanmx 

- Ticket: https://spryker.atlassian.net/browse/GLUE-317

- Academy PR: ACADEMY_URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior  | minor                 |                       |

#### Release Notes

This release introduces possibility to send synchronization message with mapping resources. It provides possibility to get data from kv-storage not only by primary keys but using another identifiers.

-----------------------------------------

#### Module SynchronizationBehavior

_**Minor:** Added functionality in a backwards-compatible manner_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Improvements

* Introduces new SynchronizationBehavior parameters (mapping_resource_key_suffix_column, mapping_resource)
* Introduces `setGeneratedKeyForMappingResource()` method in propel models with the synchronization behavior that generate key for mapping resource. 
* Introduces `syncPublishedMessageForMappingResource()` method in propel models with the synchronization behavior that sends publish messages for mapping resources. 
* Introduces `syncUnpublishedMessageForMappingResource()` method in propel models with the synchronization behavior that sends unpublish messages for mapping resources. 


