### PR TITLE
Feature/te 663/dev pass by kv storage

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,4 @@
 parameters:
     ignoreErrors:
-        -
-            message: '#Call to an undefined method .+AbstractBundleConfig::isSynchronizationEnabled\(\).#'
-            path: 'vendor/spryker/synchronization-behavior/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php'
-        -
-            message: '#Call to an undefined method .+AbstractBundleConfig::isAliasKeysEnabled\(\).#'
-            path: 'vendor/spryker/synchronization-behavior/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php'
+        - '#Call to an undefined method .+AbstractBundleConfig::isSynchronizationEnabled\(\).#'
+        - '#Call to an undefined method .+AbstractBundleConfig::isAliasKeysEnabled\(\).#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,8 @@
 parameters:
     ignoreErrors:
-
+        -
+            message: '#Call to an undefined method .+AbstractBundleConfig::isSynchronizationEnabled\(\).#'
+            path: 'vendor/spryker/synchronization-behavior/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php'
+        -
+            message: '#Call to an undefined method .+AbstractBundleConfig::isAliasKeysEnabled\(\).#'
+            path: 'vendor/spryker/synchronization-behavior/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php'

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -1012,7 +1012,7 @@ protected function setGeneratedAliasKeys()
 {
     \$mappings = $mappings;
     \$data = \$this->getData();
-    \$aliasKeys = json_decode(\$this->getAliasKeys()) ?? [];
+    \$aliasKeys = json_decode(\$this->getAliasKeys(), true) ?? [];
     foreach (\$mappings as \$mapping) {
         \$source = \$mapping['source'];
         \$destination = \$mapping['destination'];

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -184,17 +184,17 @@ class SynchronizationBehavior extends Behavior
                 $uniqueIndex->addColumn($table->getColumn('mapping_resource_key'));
                 $table->addUnique($uniqueIndex);
             }
-        }
 
-        if (!$table->hasColumn('alias_keys')) {
-            $table->addColumn([
-                'name' => 'alias_keys',
-                'type' => 'VARCHAR',
-            ]);
-            $uniqueIndex = new Unique();
-            $uniqueIndex->setName($table->getName() . '-unique-alias-keys');
-            $uniqueIndex->addColumn($table->getColumn('alias_keys'));
-            $table->addUnique($uniqueIndex);
+            if (!$table->hasColumn('alias_keys')) {
+                $table->addColumn([
+                    'name' => 'alias_keys',
+                    'type' => 'VARCHAR',
+                ]);
+                $uniqueIndex = new Unique();
+                $uniqueIndex->setName($table->getName() . '-unique-alias-keys');
+                $uniqueIndex->addColumn($table->getColumn('alias_keys'));
+                $table->addUnique($uniqueIndex);
+            }
         }
 
         if (!$table->hasColumn('key')) {

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -250,6 +250,8 @@ private \$_locator;
     {
         return "
 /**
+ * @deprecated Will be removed without replacement.
+ *
  * @return bool
  */
 public function isSendingToQueue()

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -851,7 +851,9 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
      */
     protected function hasMappings(): bool
     {
-        return isset($this->getParameters()['mappings']);
+        $parameters = $this->getParameters();
+
+        return isset($parameters['mapping']);
     }
 
     /**

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -8,6 +8,7 @@
 namespace Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior;
 
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
 use Propel\Generator\Util\PhpParser;
 use Spryker\Zed\Kernel\BundleConfigResolverAwareTrait;
@@ -196,7 +197,7 @@ class SynchronizationBehavior extends Behavior
             }
         }
 
-        if (!$table->hasColumn('alias_keys')) {
+        if ($this->shouldAddAliasKeysColumn($table)) {
             $table->addColumn([
                 'name' => 'alias_keys',
                 'type' => 'VARCHAR',
@@ -1056,5 +1057,15 @@ public function isSynchronizationEnabled(): bool
         }
 
         return $this->getConfig()->isSynchronizationEnabled();
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return bool
+     */
+    protected function shouldAddAliasKeysColumn(Table $table): bool
+    {
+        return $this->getConfig()->isAliasKeysColumnEnabled() && !$table->hasColumn('alias_keys');
     }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -38,7 +38,8 @@ class SynchronizationBehavior extends Behavior
     {
         return "
 \$this->setGeneratedKey();
-\$this->setGeneratedKeyForMappingResource();        
+\$this->setGeneratedKeyForMappingResource();      
+\$this->setGeneratedAliasKeys();      
         ";
     }
 
@@ -113,6 +114,7 @@ class SynchronizationBehavior extends Behavior
         $script .= $this->addGenerateKeyMethod();
         $script .= $this->addGenerateMappingResourceKeyMethod();
         $script .= $this->addGenerateMappingsKeyMethod();
+        $script .= $this->addGenerateAliasKeysMethod();
         $script .= $this->addSendToQueueMethod();
         $script .= $this->addSyncPublishedMessageMethod();
         $script .= $this->addSyncUnpublishedMessageMethod();
@@ -182,6 +184,17 @@ class SynchronizationBehavior extends Behavior
                 $uniqueIndex->addColumn($table->getColumn('mapping_resource_key'));
                 $table->addUnique($uniqueIndex);
             }
+        }
+
+        if (!$table->hasColumn('alias_keys')) {
+            $table->addColumn([
+                'name' => 'alias_keys',
+                'type' => 'VARCHAR',
+            ]);
+            $uniqueIndex = new Unique();
+            $uniqueIndex->setName($table->getName() . '-unique-alias-keys');
+            $uniqueIndex->addColumn($table->getColumn('alias_keys'));
+            $table->addUnique($uniqueIndex);
         }
 
         if (!$table->hasColumn('key')) {
@@ -834,6 +847,14 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
     }
 
     /**
+     * @return bool
+     */
+    protected function hasMappings(): bool
+    {
+        return isset($this->getParameters()['mappings']);
+    }
+
+    /**
      * @return string|null
      */
     protected function getQueuePoolName()
@@ -920,5 +941,41 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
     ]";
         }
         return $mappings;
+    }
+
+    /**
+     * @return string
+     */
+    protected function addGenerateAliasKeysMethod(): string
+    {
+        if (!$this->hasMappings()) {
+            return '/**
+ * @return void
+ */
+protected function setGeneratedAliasKeys()
+{
+}';
+        }
+        $mappings = $this->getMappings();
+
+        return "
+/**
+ * @return void
+ */
+protected function setGeneratedAliasKeys()
+{
+    \$mappings = $mappings;
+    \$data = \$this->getData();
+    \$aliasKeys = json_decode(\$this->getAliasKeys()) ?? [];
+    foreach (\$mappings as \$mapping) {
+        \$source = \$mapping['source'];
+        if (isset(\$data[\$source])) {
+            \$aliasKeys[] = \$this->generateMappingKey(\$source, \$data[\$source]);
+        }
+    }
+    \$aliasKeys = json_encode(array_unique(\$aliasKeys));
+    \$this->setAliasKeys(\$aliasKeys);
+}        
+        ";
     }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -232,6 +232,8 @@ class SynchronizationBehavior extends Behavior
 private \$_dataTemp;
 
 /**
+ * @deprecated Use `\Spryker\Zed\SynchronizationBehavior\SynchronizationBehaviorConfig::isSynchronizationEnabled()` instead.
+ *
  * @var bool
  */
 private \$_isSendingToQueue = true;
@@ -250,7 +252,7 @@ private \$_locator;
     {
         return "
 /**
- * @deprecated Will be removed without replacement.
+ * @deprecated Use `\Spryker\Zed\SynchronizationBehavior\SynchronizationBehaviorConfig::isSynchronizationEnabled()` instead.
  *
  * @return bool
  */
@@ -260,7 +262,7 @@ public function isSendingToQueue()
 }
 
 /**
- * @deprecated Will be removed without replacement.
+ * @deprecated Use `\Spryker\Zed\SynchronizationBehavior\SynchronizationBehaviorConfig::isSynchronizationEnabled()` instead.
  *
  * @param bool \$_isSendingToQueue
  *

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -853,7 +853,7 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
     {
         $parameters = $this->getParameters();
 
-        return isset($parameters['mapping']);
+        return isset($parameters['mappings']);
     }
 
     /**

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -994,7 +994,7 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
      */
     protected function addGenerateAliasKeysMethod(): string
     {
-        if (!$this->hasMappings()) {
+        if (!$this->shouldSetAliasKeys()) {
             return '/**
  * @return void
  */
@@ -1071,6 +1071,14 @@ public function isSynchronizationEnabled(): bool
      */
     protected function shouldAddAliasKeysColumn(Table $table): bool
     {
-        return $this->getConfig()->isAliasKeysColumnEnabled() && !$table->hasColumn('alias_keys');
+        return $this->getConfig()->isAliasKeysEnabled() && !$table->hasColumn('alias_keys');
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldSetAliasKeys(): bool
+    {
+        return $this->getConfig()->isAliasKeysEnabled() && $this->hasMappings();
     }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -184,17 +184,17 @@ class SynchronizationBehavior extends Behavior
                 $uniqueIndex->addColumn($table->getColumn('mapping_resource_key'));
                 $table->addUnique($uniqueIndex);
             }
+        }
 
-            if (!$table->hasColumn('alias_keys')) {
-                $table->addColumn([
-                    'name' => 'alias_keys',
-                    'type' => 'VARCHAR',
-                ]);
-                $uniqueIndex = new Unique();
-                $uniqueIndex->setName($table->getName() . '-unique-alias-keys');
-                $uniqueIndex->addColumn($table->getColumn('alias_keys'));
-                $table->addUnique($uniqueIndex);
-            }
+        if (!$table->hasColumn('alias_keys')) {
+            $table->addColumn([
+                'name' => 'alias_keys',
+                'type' => 'VARCHAR',
+            ]);
+            $uniqueIndex = new Unique();
+            $uniqueIndex->setName($table->getName() . '-unique-alias-keys');
+            $uniqueIndex->addColumn($table->getColumn('alias_keys'));
+            $table->addUnique($uniqueIndex);
         }
 
         if (!$table->hasColumn('key')) {

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -654,6 +654,10 @@ public function syncUnpublishedMessage()
  */
 public function syncPublishedMessageForMappingResource()
 {
+    if (!\$this->_isSendingToQueue) {
+        return;
+    }
+    
     $sendMappingStatement;
 }        
         ";
@@ -702,6 +706,10 @@ public function syncPublishedMessageForMappingResource()
  */
 public function syncUnpublishedMessageForMappingResource()
 {
+    if (!\$this->_isSendingToQueue) {
+        return;
+    }
+
     $sendMappingStatement;
 }        
         ";
@@ -745,6 +753,10 @@ public function syncUnpublishedMessageForMappingResource()
  */
 public function syncPublishedMessageForMappings()
 {
+    if (!\$this->_isSendingToQueue) {
+        return;
+    }
+    
     $sendMappingsStatement
 }        
         ";
@@ -788,6 +800,10 @@ public function syncPublishedMessageForMappings()
  */
 public function syncUnpublishedMessageForMappings()
 {
+    if (!\$this->_isSendingToQueue) {
+        return;
+    }
+    
     $sendMappingsStatement
 }        
         ";

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -1015,8 +1015,13 @@ protected function setGeneratedAliasKeys()
     \$aliasKeys = json_decode(\$this->getAliasKeys()) ?? [];
     foreach (\$mappings as \$mapping) {
         \$source = \$mapping['source'];
-        if (isset(\$data[\$source])) {
-            \$aliasKeys[] = \$this->generateMappingKey(\$source, \$data[\$source]);
+        \$destination = \$mapping['destination'];
+        if (isset(\$data[\$source]) && isset(\$data[\$destination])) {
+            \$key = \$this->generateMappingKey(\$source, \$data[\$source]);
+            \$aliasKeys[\$key] = [
+                'id' => \$data[\$destination],
+                '_timestamp' => microtime(true),
+            ];
         }
     }
     \$aliasKeys = json_encode(array_unique(\$aliasKeys));

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -27,7 +27,8 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
 
     /**
      * Specification:
-     * - If true, then the alias_keys column will be added to all the synchronization tables.
+     * - If true, then the alias_keys column is added to all the storage tables, for which mappings are defined.
+     * - The new column is populated with JSON object, containing mapping keys and their respective mapping data for each resource.
      *
      * @api
      *

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -22,6 +22,6 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
      */
     public function isSynchronizationEnabled(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -24,4 +24,17 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
     {
         return true;
     }
+
+    /**
+     * Specification:
+     * - If true, then the alias_keys column will be added to all the synchronization tables.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isAliasKeysColumnEnabled(): bool
+    {
+        return false;
+    }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -11,4 +11,17 @@ use Spryker\Zed\Kernel\AbstractBundleConfig;
 
 class SynchronizationBehaviorConfig extends AbstractBundleConfig
 {
+    /**
+     * Specification:
+     * - Enables/disables synchronization for all the modules.
+     * - This value can be overridden on a per-module basis.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isSynchronizationEnabled(): bool
+    {
+        return true;
+    }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -34,7 +34,7 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
      *
      * @return bool
      */
-    public function isAliasKeysColumnEnabled(): bool
+    public function isAliasKeysEnabled(): bool
     {
         return false;
     }

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -22,6 +22,6 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
      */
     public function isSynchronizationEnabled(): bool
     {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
- Developer(s): @asaulenko

- Ticket: https://spryker.atlassian.net/browse/TE-663

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/1547


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior  | minor                 |                       |

#### Release Notes

Made the adjustments to store key mappings in storage/search tables.

-----------------------------------------

#### Module SynchronizationBehavior

##### Change log

Improvements

- Introduced `SynchronizationBehaviorConfig::isSynchronizationEnabled()`, which allows to enable/disable synchronization.
- Added the ability to enable/disable synchronization on a per table basis by providing `synchronization_enabled` parameter to `synchronization` behavior in Propel schema files.
- Introduced `SynchronizationBehaviorConfig::isAliasKeysEnabled()`. When enabled, additional column for storing mapping keys called `alias_keys` will be added to all the storage.
- Adjusted `SynchronizationBehavior` accordingly.
