### PR TITLE
TE-3940 Updated dependency.json to use composer name instead of modul…

### DIFF
--- a/dependency.json
+++ b/dependency.json
@@ -1,6 +1,6 @@
 {
   "include": {
-    "Synchronization": "Synchronization only used within templates.",
-    "Queue": "Synchronization only used within templates."
+    "spryker/synchronization": "Synchronization only used within templates.",
+    "spryker/queue": "Synchronization only used within templates."
   }
 }


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-3940

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior  | patch {skip}           |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module SynchronizationBehavior

##### Change log

Bugfixes

Updated `dependency.json` to use Composer package name instead of module name.

