### PR TITLE
TE-7305 Enable multiple mappings in synchronization behavior

### DIFF
--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -899,9 +899,7 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
      */
     protected function hasMappings(): bool
     {
-        $parameters = $this->getParameters();
-
-        return isset($parameters['mappings']);
+        return isset($this->getParameters()['mappings']);
     }
 
     /**
@@ -964,34 +962,71 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
 
     /**
      * @throws \Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\MissingAttributeException
-     * @throws \Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\InvalidConfigurationException
      *
      * @return string
      */
     protected function getMappings(): string
     {
         $parameters = $this->getParameters();
-        $mappings = [];
-        if (isset($parameters['mappings'])) {
-            if (!isset($parameters['mappings']['value'])) {
-                throw new MissingAttributeException(sprintf(static::ERROR_MISSING_MAPPINGS_PARAMETER, $this->getTable()->getPhpName()));
-            }
-            $mappingsParts = explode(':', $parameters['mappings']['value']);
-            if (count($mappingsParts) !== 2) {
-                throw new InvalidConfigurationException(
-                    sprintf(static::ERROR_INVALID_MAPPINGS_PARAMETER, $this->getTable()->getPhpName())
-                );
-            }
 
-            $mappings = "[
-        [
-            'source' => '{$mappingsParts[0]}',
-            'destination' => '{$mappingsParts[1]}',
-        ],
-    ]";
+        if (!isset($parameters['mappings'])) {
+            return '';
         }
 
-        return $mappings;
+        if (!isset($parameters['mappings']['value'])) {
+            throw new MissingAttributeException(sprintf(static::ERROR_MISSING_MAPPINGS_PARAMETER, $this->getTable()->getPhpName()));
+        }
+
+        return $this->formatMappingsAsArrayString($parameters['mappings']['value']);
+    }
+
+    /**
+     * @param string $mappingsString
+     *
+     * @return string
+     */
+    protected function formatMappingsAsArrayString(string $mappingsString): string
+    {
+        $formattedMappings = [];
+        $formattedMappingsString = '';
+
+        foreach (explode($this->getConfig()->getMappingsDelimiter(), $mappingsString) as $mapping) {
+            $formattedMappings[] = $this->formatSingleMappingAsArrayString($mapping);
+        }
+
+        if ($formattedMappings) {
+            $formattedMappingsString = implode(',', $formattedMappings);
+            $formattedMappingsString = <<<EOT
+[$formattedMappingsString,
+    ]
+EOT;
+        }
+
+        return $formattedMappingsString;
+    }
+
+    /**
+     * @param string $mapping
+     *
+     * @throws \Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\InvalidConfigurationException
+     *
+     * @return string
+     */
+    protected function formatSingleMappingAsArrayString(string $mapping): string
+    {
+        $mappingParts = explode(':', $mapping);
+
+        if (count($mappingParts) !== 2) {
+            throw new InvalidConfigurationException(
+                sprintf(static::ERROR_INVALID_MAPPINGS_PARAMETER, $this->getTable()->getPhpName())
+            );
+        }
+
+        return "
+        [
+            'source' => '{$mappingParts[0]}',
+            'destination' => '{$mappingParts[1]}',
+        ]";
     }
 
     /**
@@ -1029,7 +1064,7 @@ protected function setGeneratedAliasKeys()
             ];
         }
     }
-    \$aliasKeys = json_encode(array_unique(\$aliasKeys));
+    \$aliasKeys = json_encode(\$aliasKeys);
     \$this->setAliasKeys(\$aliasKeys);
 }
         ";

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -967,11 +967,11 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
      */
     protected function getMappings(): string
     {
-        $parameters = $this->getParameters();
-
         if (!$this->hasMappings()) {
             return '';
         }
+
+        $parameters = $this->getParameters();
 
         if (!isset($parameters['mappings']['value'])) {
             throw new MissingAttributeException(sprintf(static::ERROR_MISSING_MAPPINGS_PARAMETER, $this->getTable()->getPhpName()));

--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -969,7 +969,7 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
     {
         $parameters = $this->getParameters();
 
-        if (!isset($parameters['mappings'])) {
+        if (!$this->hasMappings()) {
             return '';
         }
 
@@ -977,7 +977,7 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
             throw new MissingAttributeException(sprintf(static::ERROR_MISSING_MAPPINGS_PARAMETER, $this->getTable()->getPhpName()));
         }
 
-        return $this->formatMappingsAsArrayString($parameters['mappings']['value']);
+        return $this->formatMappings($parameters['mappings']['value']);
     }
 
     /**
@@ -985,22 +985,19 @@ protected function generateMappingKey(\$source, \$sourceIdentifier)
      *
      * @return string
      */
-    protected function formatMappingsAsArrayString(string $mappingsString): string
+    protected function formatMappings(string $mappingsString): string
     {
         $formattedMappings = [];
-        $formattedMappingsString = '';
 
         foreach (explode($this->getConfig()->getMappingsDelimiter(), $mappingsString) as $mapping) {
-            $formattedMappings[] = $this->formatSingleMappingAsArrayString($mapping);
+            $formattedMappings[] = $this->formatSingleMapping($mapping);
         }
 
-        if ($formattedMappings) {
-            $formattedMappingsString = implode(',', $formattedMappings);
-            $formattedMappingsString = <<<EOT
+        $formattedMappingsString = implode(',', $formattedMappings);
+        $formattedMappingsString = <<<EOT
 [$formattedMappingsString,
     ]
 EOT;
-        }
 
         return $formattedMappingsString;
     }
@@ -1012,7 +1009,7 @@ EOT;
      *
      * @return string
      */
-    protected function formatSingleMappingAsArrayString(string $mapping): string
+    protected function formatSingleMapping(string $mapping): string
     {
         $mappingParts = explode(':', $mapping);
 

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -11,6 +11,8 @@ use Spryker\Zed\Kernel\AbstractBundleConfig;
 
 class SynchronizationBehaviorConfig extends AbstractBundleConfig
 {
+    protected const MAPPINGS_DELIMITER = ';';
+
     /**
      * Specification:
      * - Enables/disables synchronization for all the modules.
@@ -37,5 +39,18 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
     public function isAliasKeysEnabled(): bool
     {
         return false;
+    }
+
+    /**
+     * Specification:
+     * - Returns the delimiter used to separate multiple mappings in schema configuration.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getMappingsDelimiter(): string
+    {
+        return static::MAPPINGS_DELIMITER;
     }
 }

--- a/tests/SprykerTest/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehaviorTest.php
+++ b/tests/SprykerTest/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehaviorTest.php
@@ -8,7 +8,6 @@
 namespace SprykerTest\Zed\SynchronizationBehavior\Persistence\Propel\Behavior;
 
 use Codeception\Test\Unit;
-use Codeception\Util\Stub;
 use Propel\Generator\Model\Table;
 use Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\InvalidConfigurationException;
 use Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\MissingAttributeException;
@@ -142,7 +141,7 @@ class SynchronizationBehaviorTest extends Unit
     protected function setUpSynchronizationBehavior(): void
     {
         $this->synchronizationBehavior = new SynchronizationBehavior();
-        $this->synchronizationBehavior->setConfig($this->createSynchronizationBehaviorConfigMock());
+        $this->synchronizationBehavior->setConfig(new SynchronizationBehaviorConfig());
         $this->synchronizationBehavior->setTable(new Table());
         $this->synchronizationBehavior->setParameters([
             'queue_group' => [
@@ -151,18 +150,6 @@ class SynchronizationBehaviorTest extends Unit
             'resource' => [
                 'value' => 'resource',
             ],
-        ]);
-    }
-
-    /**
-     * @param string $mappingsDelimiter
-     *
-     * @return \Spryker\Zed\SynchronizationBehavior\SynchronizationBehaviorConfig|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function createSynchronizationBehaviorConfigMock($mappingsDelimiter = ';'): SynchronizationBehaviorConfig
-    {
-        return Stub::make(SynchronizationBehaviorConfig::class, [
-            'getMappingsDelimiter' => $mappingsDelimiter,
         ]);
     }
 }

--- a/tests/SprykerTest/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehaviorTest.php
+++ b/tests/SprykerTest/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehaviorTest.php
@@ -69,6 +69,7 @@ class SynchronizationBehaviorTest extends Unit
      */
     public function mappingsDataProvider(): array
     {
+        // Indentation is done like this on purpose. Changing it will make the corresponding test to fail.
         return [
             'single mapping' => [
                 '$mappings = [

--- a/tests/SprykerTest/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehaviorTest.php
+++ b/tests/SprykerTest/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehaviorTest.php
@@ -8,6 +8,12 @@
 namespace SprykerTest\Zed\SynchronizationBehavior\Persistence\Propel\Behavior;
 
 use Codeception\Test\Unit;
+use Codeception\Util\Stub;
+use Propel\Generator\Model\Table;
+use Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\InvalidConfigurationException;
+use Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\Exception\MissingAttributeException;
+use Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\SynchronizationBehavior;
+use Spryker\Zed\SynchronizationBehavior\SynchronizationBehaviorConfig;
 
 /**
  * Auto-generated group annotations
@@ -23,4 +29,140 @@ use Codeception\Test\Unit;
  */
 class SynchronizationBehaviorTest extends Unit
 {
+    /**
+     * @var \Spryker\Zed\SynchronizationBehavior\Persistence\Propel\Behavior\SynchronizationBehavior
+     */
+    protected $synchronizationBehavior;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpSynchronizationBehavior();
+    }
+
+    /**
+     * @dataProvider mappingsDataProvider
+     *
+     * @param string $expectedMappingsString
+     * @param array $mappingsConfiguration
+     *
+     * @return void
+     */
+    public function testsBuildsCorrectMappings(string $expectedMappingsString, array $mappingsConfiguration): void
+    {
+        // Arrange
+        $this->synchronizationBehavior->addParameter($mappingsConfiguration);
+
+        // Act
+        $result = $this->synchronizationBehavior->objectMethods();
+
+        // Assert
+        $this->assertStringContainsString($expectedMappingsString, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function mappingsDataProvider(): array
+    {
+        return [
+            'single mapping' => [
+                '$mappings = [
+        [
+            \'source\' => \'foo\',
+            \'destination\' => \'bar\',
+        ],
+    ];',
+                [
+                    'name' => 'mappings',
+                    'value' => 'foo:bar',
+                ],
+            ],
+            'multiple mappings' => [
+                '$mappings = [
+        [
+            \'source\' => \'foo\',
+            \'destination\' => \'bar\',
+        ],
+        [
+            \'source\' => \'baz\',
+            \'destination\' => \'foobar\',
+        ],
+        [
+            \'source\' => \'foobar\',
+            \'destination\' => \'baz\',
+        ],
+    ];',
+                [
+                    'name' => 'mappings',
+                    'value' => 'foo:bar;baz:foobar;foobar:baz',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function testExceptionIsThrownWhenNoMappingValueIsProvided(): void
+    {
+        $this->expectException(MissingAttributeException::class);
+
+        $mapping = [
+            'name' => 'mappings',
+        ];
+        $this->synchronizationBehavior->addParameter($mapping);
+
+        $this->synchronizationBehavior->objectMethods();
+    }
+
+    /**
+     * @return void
+     */
+    public function testExceptionIsThrownWhenMappingValueIsInvalid(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $mapping = [
+            'name' => 'mappings',
+            'value' => 'foobar',
+        ];
+        $this->synchronizationBehavior->addParameter($mapping);
+
+        $this->synchronizationBehavior->objectMethods();
+    }
+
+    /**
+     * @return void
+     */
+    protected function setUpSynchronizationBehavior(): void
+    {
+        $this->synchronizationBehavior = new SynchronizationBehavior();
+        $this->synchronizationBehavior->setConfig($this->createSynchronizationBehaviorConfigMock());
+        $this->synchronizationBehavior->setTable(new Table());
+        $this->synchronizationBehavior->setParameters([
+            'queue_group' => [
+                'value' => 'queue_group',
+            ],
+            'resource' => [
+                'value' => 'resource',
+            ],
+        ]);
+    }
+
+    /**
+     * @param string $mappingsDelimiter
+     *
+     * @return \Spryker\Zed\SynchronizationBehavior\SynchronizationBehaviorConfig|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function createSynchronizationBehaviorConfigMock($mappingsDelimiter = ';'): SynchronizationBehaviorConfig
+    {
+        return Stub::make(SynchronizationBehaviorConfig::class, [
+            'getMappingsDelimiter' => $mappingsDelimiter,
+        ]);
+    }
 }

--- a/tests/SprykerTest/Zed/SynchronizationBehavior/_support/SynchronizationBehaviorTester.php
+++ b/tests/SprykerTest/Zed/SynchronizationBehavior/_support/SynchronizationBehaviorTester.php
@@ -28,8 +28,4 @@ use Codeception\Actor;
 class SynchronizationBehaviorTester extends Actor
 {
     use _generated\SynchronizationBehaviorTesterActions;
-
-   /**
-    * Define custom actions here
-    */
 }


### PR DESCRIPTION
- Developer(s): @asaulenko

- Ticket: https://spryker.atlassian.net/browse/TE-7305

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/3014

- PR Overview: TBA

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior           | minor                 |                       |

-----------------------------------------

#### Module SynchronizationBehavior

##### Change log

Improvements

- Adjusted `SynchronizationBehavior` to allow multiple mappings to be saved to the storage.
- Introduced `SynchronizationBehaviorConfig::getMappingsDelimiter()` to control the delimiter used to separate multiple mappings in Propel schema files.

