### PR TITLE
TE-8144 configuration for data field type

### DIFF
--- a/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/Persistence/Propel/Behavior/SynchronizationBehavior.php
@@ -149,7 +149,7 @@ class SynchronizationBehavior extends Behavior
         if (!$table->hasColumn('data')) {
             $table->addColumn([
                 'name' => 'data',
-                'type' => 'LONGVARCHAR',
+                'type' => $this->getConfig()->getDataColumnType(),
             ]);
         }
 

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -14,6 +14,11 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
     protected const MAPPINGS_DELIMITER = ';';
 
     /**
+     * @uses \Propel\Generator\Model\PropelTypes::CLOB
+     */
+    protected const DATA_COLUMN_TYPE = 'CLOB';
+
+    /**
      * Specification:
      * - Enables/disables synchronization for all the modules.
      * - This value can be overridden on a per-module basis.
@@ -52,5 +57,18 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
     public function getMappingsDelimiter(): string
     {
         return static::MAPPINGS_DELIMITER;
+    }
+
+    /**
+     * Specification:
+     * - Returns the the Propel type for "data" column.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getDataColumnType(): string
+    {
+        return static::DATA_COLUMN_TYPE;
     }
 }

--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -61,7 +61,7 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
 
     /**
      * Specification:
-     * - Returns the the Propel type for "data" column.
+     * - Returns Propel's type for `data` column.
      *
      * @api
      *


### PR DESCRIPTION
- Developer(s): @Nidhognit

- Ticket: https://spryker.atlassian.net/browse/TE-8144

- Release Group: https://release.spryker.com/release-groups/view/3176


#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior  | minor                 |                       |

-----------------------------------------

#### Module SynchronizationBehavior

##### Change log

Fixes
- Introduced `SynchronizationBehaviorConfig::getDataColumnType()` that define default type for all `data` columns.
- Adjusted default column type for `data` field, now it's Propel `CLOB` type. For PostgreSQL thats mean no changes, for MariaDB field type changed from TEXT to LONGTEXT.

