### PR TITLE
TE-8938 Enabled alias_keys to be generated by default.

### DIFF
--- a/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
+++ b/src/Spryker/Zed/SynchronizationBehavior/SynchronizationBehaviorConfig.php
@@ -43,7 +43,7 @@ class SynchronizationBehaviorConfig extends AbstractBundleConfig
      */
     public function isAliasKeysEnabled(): bool
     {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-8938

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/3403

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SynchronizationBehavior  | minor                 |                       |

-----------------------------------------

#### Module SynchronizationBehavior

##### Change log

Improvements

- Enabled `alias_keys` to be generated by default. This fixes the issue that mapping keys were not exported to the storage when running `console sync:data`.

